### PR TITLE
feat: support mobile touch screen + tweak layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ pnpm build
 pnpm release-production
 ```
 
-![image](https://user-images.githubusercontent.com/4232207/210215422-c80aeb30-4d80-4970-89e4-aa04175e09a6.png)
+![image](https://user-images.githubusercontent.com/4232207/210296586-61ad5432-4d60-45b2-822f-1518e698b257.png)
 
 ## references
 

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -120,8 +120,8 @@ function AppInner() {
 
   return (
     <div className="h-full w-full flex flex-col relative">
-      <header className="w-full flex justify-end items-center p-2 px-4">
-        <h1 className="text-2xl">Soundfont Player</h1>
+      <header className="w-full flex justify-end items-center p-2 px-4 shadow-md shadow-black/[0.05] dark:shadow-black/[0.7]">
+        <h1 className="text-xl">Soundfont Player</h1>
         <div className="flex-1"></div>
         <div className="flex gap-3 flex items-center">
           <Transition

--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -119,44 +119,50 @@ function AppInner() {
   });
 
   return (
-    <div className="h-full w-full flex flex-col justify-center items-center gap-2 relative">
-      <div className="absolute right-3 top-3 flex gap-3 flex items-center">
-        <Transition
-          appear
-          show={customNode.loading}
-          className="spinner w-5 h-5 transition duration-1000"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        />
-        <button
-          className="btn btn-ghost flex items-center"
-          onClick={() => {
-            if (audioState === "suspended") {
-              audio.audioContext.resume();
-            } else if (audioState === "running") {
-              audio.audioContext.suspend();
-            }
-          }}
-        >
-          {audioState === "suspended" && (
-            <span className="i-ri-volume-mute-line w-6 h-6"></span>
-          )}
-          {audioState === "running" && (
-            <span className="i-ri-volume-up-line w-6 h-6"></span>
-          )}
-        </button>
-        <ThemeSelectButton />
-        <a
-          className="flex items-center btn btn-ghost"
-          href="https://github.com/hi-ogawa/web-audio-worklet-rust"
-          target="_blank"
-        >
-          <span className="i-ri-github-line w-6 h-6"></span>
-        </a>
-      </div>
-      <KeyboardComponent sendNoteOn={sendNoteOn} sendNoteOff={sendNoteOff} />
+    <div className="h-full w-full flex flex-col relative">
+      <header className="w-full flex justify-end items-center p-2 px-4">
+        <h1 className="text-2xl">Soundfont Player</h1>
+        <div className="flex-1"></div>
+        <div className="flex gap-3 flex items-center">
+          <Transition
+            appear
+            show={customNode.loading}
+            className="spinner w-5 h-5 transition duration-1000"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          />
+          <button
+            className="btn btn-ghost flex items-center"
+            onClick={() => {
+              if (audioState === "suspended") {
+                audio.audioContext.resume();
+              } else if (audioState === "running") {
+                audio.audioContext.suspend();
+              }
+            }}
+          >
+            {audioState === "suspended" && (
+              <span className="i-ri-volume-mute-line w-6 h-6"></span>
+            )}
+            {audioState === "running" && (
+              <span className="i-ri-volume-up-line w-6 h-6"></span>
+            )}
+          </button>
+          <ThemeSelectButton />
+          <a
+            className="flex items-center btn btn-ghost"
+            href="https://github.com/hi-ogawa/web-audio-worklet-rust"
+            target="_blank"
+          >
+            <span className="i-ri-github-line w-6 h-6"></span>
+          </a>
+        </div>
+      </header>
+      <main className="flex-[1_1_auto] flex items-center">
+        <KeyboardComponent sendNoteOn={sendNoteOn} sendNoteOff={sendNoteOff} />
+      </main>
     </div>
   );
 }
@@ -207,10 +213,10 @@ function KeyboardComponent({
   return (
     <div
       // use webkit-scrollbar to avoid overlay scrollbar (otherwise, users cannot scroll keyboard on touch screen device)
-      className="w-full overflow-x-scroll scrollbar pb-2"
+      className="w-full overflow-x-scroll scrollbar pb-2 max-h-[200px] h-full"
       ref={refScrollOnMount}
     >
-      <div className="relative flex select-none touch-none">
+      <div className="relative flex select-none touch-none h-full">
         {range(parseMidiNote("C1"), parseMidiNote("E9") + 1)
           .map((noteNum) => [noteNum, stringifyMidiNote(noteNum)] as const)
           .map(([noteNum, note]) => (
@@ -219,8 +225,8 @@ function KeyboardComponent({
               data-note={note} // scroll to C4 on mount
               className={
                 isBlackKey(noteNum)
-                  ? "z-1 absolute top-0 bg-black flex-1 w-[44px] h-[120px] mx-[3px] rounded rounded-t-none"
-                  : "bg-white flex-none w-[48px] h-[200px] mx-[1px] border border-gray-400 dark:border-transparent transition rounded rounded-t-none inline-flex justify-center items-end"
+                  ? "z-1 absolute top-0 bg-black flex-1 w-[44px] h-[60%] mx-[3px] rounded rounded-t-none"
+                  : "bg-white flex-none w-[48px] h-full mx-[1px] border border-gray-400 dark:border-transparent transition rounded rounded-t-none inline-flex justify-center items-end"
               }
               style={
                 isBlackKey(noteNum)

--- a/packages/app/src/audio-worklet/soundfont-processor.ts
+++ b/packages/app/src/audio-worklet/soundfont-processor.ts
@@ -11,6 +11,8 @@ export class SoundfontProcessor extends AudioWorkletProcessor {
 
     // instantiate wasm
     // TODO: pass soundfont data via processorOptions
+    // TODO: we could also pass initial data by `postMessage` which ensures zero-copy
+    // TODO: we could also reuse comlink interface for simpler communication https://github.com/GoogleChromeLabs/comlink
     const { processorOptions } = options;
     const { bufferSource } = processorOptions;
     tinyassert(bufferSource instanceof ArrayBuffer);
@@ -23,7 +25,7 @@ export class SoundfontProcessor extends AudioWorkletProcessor {
   private handleMessage = (e: MessageEvent) => {
     const message = Z_SOUNDFONT_PROCESSOR_EVENT.parse(e.data);
     if (message.type === "note_on") {
-      this.soundfontPlayer.note_on(message.key);
+      this.soundfontPlayer.note_on(message.key, 127);
     }
     if (message.type === "note_off") {
       this.soundfontPlayer.note_off(message.key);

--- a/packages/app/src/styles/index.css
+++ b/packages/app/src/styles/index.css
@@ -29,3 +29,42 @@ body {
 body {
   --at-apply: "transition";
 }
+
+/* webkit scrollbar based on https://github.com/action-hong/unocss-preset-scrollbar */
+.scrollbar::-webkit-scrollbar {
+  width: var(--scrollbar-width);
+  height: var(--scrollbar-height);
+}
+.scrollbar::-webkit-scrollbar-thumb {
+  /* TODO: no transition color? */
+  background-color: var(--scrollbar-thumb);
+}
+.scrollbar::-webkit-scrollbar-track {
+  background-color: var(--scrollbar-track);
+}
+.scrollbar::-webkit-scrollbar-thumb {
+  border-radius: var(--scrollbar-thumb-radius);
+}
+.scrollbar::-webkit-scrollbar-track {
+  border-radius: var(--scrollbar-track-radius);
+}
+.scrollbar {
+  --scrollbar-width: 10px;
+  --scrollbar-height: var(--scrollbar-width);
+  --scrollbar-track-radius: 0px;
+  --scrollbar-thumb-radius: calc(var(--scrollbar-width) / 2);
+}
+:root {
+  --scrollbar-track: #f1f1f1;
+  --scrollbar-thumb: #c1c1c1;
+}
+.dark {
+  --scrollbar-track: #424242;
+  --scrollbar-thumb: #686868;
+}
+@media (pointer: coarse) {
+  /* thick scrollbar for touch screen so that it's easier to grab */
+  .scrollbar {
+    --scrollbar-width: 24px;
+  }
+}

--- a/packages/app/src/utils/conversion.ts
+++ b/packages/app/src/utils/conversion.ts
@@ -21,7 +21,7 @@ export function parseMidiNote(note: string): number {
 
   const octave = Number(note[note.length - 1]);
   tinyassert(Number.isInteger(octave));
-  tinyassert(1 <= octave && octave <= 10);
+  tinyassert(1 <= octave && octave < 10);
 
   return index + (octave + 1) * 12;
 }

--- a/packages/wasm/src/soundfont_player.rs
+++ b/packages/wasm/src/soundfont_player.rs
@@ -26,12 +26,12 @@ impl SoundfontPlayer {
         Self { synth }
     }
 
-    pub fn note_on(&mut self, key: u8) {
+    pub fn note_on(&mut self, key: u8, vel: u8) {
         self.synth
             .send_event(MidiEvent::NoteOn {
                 channel: 0,
                 key,
-                vel: 100,
+                vel,
             })
             .unwrap();
     }


### PR DESCRIPTION
- [x] more range of keys
  - mobile (touch screen)
    - how to deal with touch scroll?
    - cannot long press?
    - multi touch?
    - https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action
  - it might be better to traverse TouchList on each animation frame to track note states
  - `webkit-scrollbar` for non-overlay scroll handle
- [x] UI tweak
  - header layout
  - title
  - layout for landscape
- [ ] ability to select/download soundfont
  - [ ] cache soundfont
- [ ] global gain control


## screenshot

![image](https://user-images.githubusercontent.com/4232207/210296586-61ad5432-4d60-45b2-822f-1518e698b257.png)

- thick scrollbar on touch screen device

![image](https://user-images.githubusercontent.com/4232207/210296349-41d2d5ca-2b00-4353-8f73-1c54b9f56f6a.png)

- landscape layout

![image](https://user-images.githubusercontent.com/4232207/210296326-0e3e56b4-aa27-45ec-9ac3-a68e0b46102b.png)
